### PR TITLE
kernelsu: fix type mismatches in ksu_get_ksym_size()

### DIFF
--- a/kernel/downstream/kallsyms_common.h
+++ b/kernel/downstream/kallsyms_common.h
@@ -382,10 +382,10 @@ found:
 }
 
 // ksu_get_ksym_size, return symbol size, return retfail if fail.
-static noinline size_t ksu_get_ksym_size(uintptr_t symbol_addr, ptrdiff_t retfail)
+static noinline size_t ksu_get_ksym_size(uintptr_t symbol_addr, size_t retfail)
 {
-	size_t offset = 0;
-	size_t symbolsize = 0;
+	unsigned long offset = 0;
+	unsigned long symbolsize = 0;
 
 	kallsyms_lookup_size_offset(symbol_addr, &symbolsize, &offset);
 


### PR DESCRIPTION
kallsyms_lookup_size_offset() expects unsigned long* for its symbolsize/offset out-parameters, but ksu_get_ksym_size() declared them as size_t. On targets where size_t is 32-bit (unsigned int) while unsigned long is 64-bit, this produced:

  error: incompatible pointer types passing 'size_t *' (aka
  'unsigned int *') to parameter of type 'unsigned long *'

Change symbolsize/offset to unsigned long to match the kallsyms API.

Also change the retfail parameter from ptrdiff_t (signed) to size_t to match the function's own unsigned return type, avoiding an implicit signed-to-unsigned conversion on the fallback return path.